### PR TITLE
Allow creating sockets without async, make buffers unbound, update deps

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -49,10 +49,10 @@ der-parser = "5.0"
 x509-parser = "0.9"
 webpki = "0.21.4"
 rand_core = "0.6.3"
-p256 = { version = "0.10", features=["default", "ecdh", "ecdsa"] }
+p256 = { version = "0.11.1", features=["default", "ecdh", "ecdsa"] }
 x25519-dalek = "2.0.0-pre.1"
 hmac = "0.10.1"
-elliptic-curve = { version = "0.11.12", features = ["default", "ecdh"] }
+elliptic-curve = { version = "0.12.3", features = ["default", "ecdh", "sec1"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 base64 = "0.13.0"
 

--- a/client/src/webrtc/crates/dtls/prf/mod.rs
+++ b/client/src/webrtc/crates/dtls/prf/mod.rs
@@ -89,7 +89,7 @@ fn elliptic_curve_pre_master_secret(
                 p256::EncodedPoint::from_bytes(public_key).map_err(elliptic_curve::Error::from)?;
             let public = p256::PublicKey::from_sec1_bytes(pub_key.as_ref())?;
             if let NamedCurvePrivateKey::EphemeralSecretP256(secret) = private_key {
-                return Ok(secret.diffie_hellman(&public).as_bytes().to_vec());
+                return Ok(secret.diffie_hellman(&public).raw_secret_bytes().to_vec());
             }
         }
         NamedCurve::X25519 => {

--- a/client/src/webrtc/crates/ice/agent/agent_internal.rs
+++ b/client/src/webrtc/crates/ice/agent/agent_internal.rs
@@ -407,6 +407,7 @@ impl AgentInternal {
         local: Arc<dyn Candidate + Send + Sync>,
         remote: Arc<dyn Candidate + Send + Sync>,
     ) {
+        log::debug!("adding a pair {local} {remote}");
         let p = Arc::new(CandidatePair::new(
             local,
             remote,
@@ -514,6 +515,7 @@ impl AgentInternal {
     /// Assumes you are holding the lock (must be execute using a.run).
     pub(crate) async fn add_remote_candidate(&self, c: &Arc<dyn Candidate + Send + Sync>) {
         let network_type = c.network_type();
+        log::debug!("adding a remote candidate {c} {network_type:?}");
 
         {
             let mut remote_candidates = self.remote_candidates.lock().await;
@@ -577,6 +579,7 @@ impl AgentInternal {
                 }
             }
 
+            log::debug!("adding local {} {:?}", c, network_type);
             if let Some(cands) = local_candidates.get_mut(&network_type) {
                 cands.push(c.clone());
             } else {
@@ -593,6 +596,7 @@ impl AgentInternal {
         }
 
         for cand in remote_cands {
+            log::debug!("adding remote {}", c);
             self.add_pair(c.clone(), cand).await;
         }
 

--- a/client/src/webrtc/crates/ice/util/mod.rs
+++ b/client/src/webrtc/crates/ice/util/mod.rs
@@ -65,9 +65,7 @@ pub(crate) async fn local_interfaces(
 
         for ipnet in iface.addrs() {
             let ipaddr = ipnet.addr();
-            if !ipaddr.is_loopback()
-                && ((ipv4requested && ipaddr.is_ipv4()) || (ipv6requested && ipaddr.is_ipv6()))
-            {
+            if ipv4requested && ipaddr.is_ipv4() || ipv6requested && ipaddr.is_ipv6() {
                 ips.insert(ipaddr);
             }
         }


### PR DESCRIPTION
- Allows creating sockets without `async`. In the context of Bevy, it's useful to be able to store `(Socket, SocketIo)` into a resource without having to make an `async` call first.
- Updates some dependencies
  - In my project, I had a conflict with a crate providing `jwks` functionality, which required a newer `p256` version
- Makes channels unbound. I don't think there's a good reason to have them limited to `8`. The change will simplify users' code so that they won't need to handle errors with some sort of backpressure logic
- Allows loopback interface. Is there a reason why it was ignored in the first place? I hope that not ignoring it won't break anything, at least, it allowed me to test things without internet/lan